### PR TITLE
Remove duplicate classification section

### DIFF
--- a/src/components/formSections/DatosInstalacionSection.tsx
+++ b/src/components/formSections/DatosInstalacionSection.tsx
@@ -92,11 +92,10 @@ const DatosInstalacionSection = ({
   return (
     <div className="space-y-6">
       <Tabs defaultValue="instalacion" className="w-full">
-        <TabsList className="grid w-full grid-cols-4">
+        <TabsList className="grid w-full grid-cols-3">
           <TabsTrigger value="instalacion">2. Datos Instalación</TabsTrigger>
           <TabsTrigger value="instalador">3. Datos Instalador</TabsTrigger>
           <TabsTrigger value="tecnicos">4. Datos Técnicos</TabsTrigger>
-          <TabsTrigger value="clasificacion">5. Clasificación</TabsTrigger>
         </TabsList>
 
         <TabsContent value="instalacion" className="space-y-6">
@@ -189,20 +188,15 @@ const DatosInstalacionSection = ({
         </TabsContent>
 
         <TabsContent value="instalador" className="space-y-6">
-          <DatosInstaladorSection 
-            onChange={handleInstaladorChange} 
-          />
-        </TabsContent>
-
-        <TabsContent value="tecnicos" className="space-y-6">
-          <DatosTecnicosSection 
+          <DatosInstaladorSection onChange={handleInstaladorChange} />
+          <ClasificacionSection
             onChange={handleTecnicosChange}
             onGasFluoradoChange={handleGasFluoradoChange}
           />
         </TabsContent>
 
-        <TabsContent value="clasificacion" className="space-y-6">
-          <ClasificacionSection
+        <TabsContent value="tecnicos" className="space-y-6">
+          <DatosTecnicosSection
             onChange={handleTecnicosChange}
             onGasFluoradoChange={handleGasFluoradoChange}
           />

--- a/src/components/formSections/DatosTitularSection.tsx
+++ b/src/components/formSections/DatosTitularSection.tsx
@@ -7,7 +7,6 @@ import { Card } from "@/components/ui/card";
 import { Separator } from "@/components/ui/separator";
 import DatosInstalacionSection from "./DatosInstalacionSection";
 import DatosInstaladorSection from "./DatosInstaladorSection";
-import ClasificacionSection from "./ClasificacionSection";
 import DatosTecnicosSection from "./DatosTecnicosSection";
 import ExcelUploader from "../ExcelUploader";
 import WordDocumentTemplate from "../WordDocumentTemplate";
@@ -108,12 +107,6 @@ const DatosTitularSection = ({
             codigoPostal={codigoPostal}
             onNormativaChange={handleNormativaChange}
           />
-          <div className="mt-6">
-            <ClasificacionSection 
-              onChange={onChange} 
-              onGasFluoradoChange={handleGasFluoradoChange}  
-            />
-          </div>
         </TabsContent>
         
         <TabsContent value="proyecto" className="space-y-6">


### PR DESCRIPTION
## Summary
- remove extra `ClasificacionSection` from `DatosTitularSection`
- move classification UI into the "Datos Instalador" tab
- drop the dedicated classification tab

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841bc0d52588321975fafe8b4e22fa9